### PR TITLE
u/lskelvin/png-plus-fix-test: Test fix for PNG filenames with '+' character

### DIFF
--- a/doc/lsst.source.injection/reference/11_make_injection_pipeline.rst
+++ b/doc/lsst.source.injection/reference/11_make_injection_pipeline.rst
@@ -300,11 +300,11 @@ The output PNG file from the above example is shown below:
 .. list-table::
     :widths: 1 1 1
 
-    * - .. image:: ../_assets/DRP-RC2+injection_step1_inject_exposure.png
+    * - .. image:: ../_assets/DRP-RC2\+injection_step1_inject_exposure.png
             :width: 100%
-      - .. image:: ../_assets/DRP-RC2+injection_step1_inject_visit.png
+      - .. image:: ../_assets/DRP-RC2\+injection_step1_inject_visit.png
             :width: 100%
-      - .. image:: ../_assets/DRP-RC2+injection_step3_inject_coadd.png
+      - .. image:: ../_assets/DRP-RC2\+injection_step3_inject_coadd.png
             :width: 100%
     * - The ``inject_exposure`` task merged into the HSC DRP-RC2 step 1 subset.
       - The ``inject_visit`` task merged into the HSC DRP-RC2 step 1 subset.


### PR DESCRIPTION
This PR tests a fix to PNG filenames containing a plus character. The fix is to escape the + character with a backslash. Local testing seems to suggest this is supported by Sphinx, however, local builds of the documentation do _not_ display the issue that the main pipelines.lsst.io builds display, hence the need for this live test.