### PR TITLE
DM-48753: Add missing __init__.py

### DIFF
--- a/python/lsst/__init__.py
+++ b/python/lsst/__init__.py
@@ -1,0 +1,3 @@
+import pkgutil
+
+__path__ = pkgutil.extend_path(__path__, __name__)

--- a/python/lsst/source/__init__.py
+++ b/python/lsst/source/__init__.py
@@ -1,0 +1,3 @@
+import pkgutil
+
+__path__ = pkgutil.extend_path(__path__, __name__)


### PR DESCRIPTION
Things sometimes work with them missing but it depends on how EUPS has configured PYTHONPATH relative to other lsst packages.