### PR TITLE
DM-48896: Create pipeline yaml files for DRP with ComCam

### DIFF
--- a/python/lsst/source/injection/bin/make_injection_pipeline.py
+++ b/python/lsst/source/injection/bin/make_injection_pipeline.py
@@ -136,7 +136,7 @@ the pipeline. A warning is logged for each contract that is removed.
     )
     parser.add_argument(
         "-s",
-        "--subset-name",
+        "--subset-names",
         type=str,
         help="All tasks from any additional pipelines will be added to this subset."
         "The subset will be created if it does not already exist.",

--- a/python/lsst/source/injection/utils/_make_injection_pipeline.py
+++ b/python/lsst/source/injection/utils/_make_injection_pipeline.py
@@ -86,7 +86,7 @@ def make_injection_pipeline(
     instrument: str | None = None,
     config: str | list[str] | None = None,
     additional_pipelines: list[Pipeline] | list[str] | None = None,
-    subset_name: str | None = None,
+    subset_names: str | list[str] | None = None,
     subset_description: str = "",
     log_level: int = logging.INFO,
 ) -> Pipeline:
@@ -135,12 +135,12 @@ def make_injection_pipeline(
         Location(s) of additional input pipeline definition YAML file(s).
         Tasks from these additional pipelines will be added to the output
         injection pipeline.
-    subset_name: `str`, optional
-        All tasks from any additional pipelines will be added to this subset.
+    subset_names: `str`, optional
+        All tasks from any additional pipelines will be added to this subsets.
         The subset will be created if it does not already exist.
-    subset_description: `str`, optional
-        The description given to a new subset which holds tasks from additional
-        pipelines provided. Note: this argument is ignored if the subset
+    subset_descriptions: `str`, optional
+        The descriptions given to new subsets which hold tasks from additional
+        pipelines provided. Note: this argument is ignored if the subsets
         already exists.
     log_level : `int`, optional
         The log level to use for logging.
@@ -369,14 +369,17 @@ def make_injection_pipeline(
             pipeline.mergePipeline(additional_pipeline)
 
         # Add all tasks to subset_name. If the subset does not exist create it.
-        if isinstance(subset_name, str):
-            if subset_name in pipeline.subsets.keys():
-                for additional_task in additional_tasks:
-                    pipeline.addLabelToSubset(subset_name, additional_task)
-                    subset_grammar = f"the existing subset {subset_name}"
-            else:
-                pipeline.addLabeledSubset(subset_name, subset_description, additional_tasks)
-                subset_grammar = f"a new subset {subset_name}"
+        if isinstance(subset_names, str):
+            subset_names = subset_names.split(",")
+        if isinstance(subset_names, list):
+            for subset_name in subset_names:
+                if subset_name in pipeline.subsets.keys():
+                    for additional_task in additional_tasks:
+                        pipeline.addLabelToSubset(subset_name, additional_task)
+                        subset_grammar = f"the existing subset {subset_name}"
+                else:
+                    pipeline.addLabeledSubset(subset_name, subset_description, additional_tasks)
+                    subset_grammar = f"a new subset {subset_name}"
 
         # Logging info.
         task_grammar = "task" if len(additional_tasks) == 1 else "tasks"


### PR DESCRIPTION
Modify the source injection `make_injection_pipeline` to accomodate for multiple subset names, config overrides on post injected tasks, and the new dataset types.
